### PR TITLE
Removed invalid NPM post install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "build": "gulp build",
     "lint": "gulp lint",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "node dev/scripts/install.js"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hey @gabriel-hook 

Since you removed the script that the `npm` postinstall directive referred to, I thought it'd make sense to remove the directive itself.
